### PR TITLE
Replace ticket sales buttons with livestream buttons

### DIFF
--- a/src/components/page/header.astro
+++ b/src/components/page/header.astro
@@ -37,7 +37,7 @@ const { withLogo = true, withoutMenu = false }: Props = Astro.props;
                 <Button otherKeys={{"data-menu-toggle": true}} ty="hamburger" />
                 <div class="menu" data-menu>
                     <Menu location="header" />
-                    <Button link="https://event.onliveevent.nl/rustweek-2026">Tickets</Button>
+                    <Button link="/live">Livestream</Button>
                 </div>
                 <div class="overlay" data-menu-overlay></div>
             )

--- a/src/components/page/menu.astro
+++ b/src/components/page/menu.astro
@@ -57,6 +57,9 @@ const { location }: Props = Astro.props;
         <a href="/getting-there">Getting there</a>
       </li>
       <li class="child" role="menuitem">
+        <a href="https://event.onliveevent.nl/rustweek-2026">Tickets</a>
+      </li>
+      <li class="child" role="menuitem">
         <a href="/hotels">Hotels</a>
       </li>
       <li class="child" role="menuitem">
@@ -79,7 +82,7 @@ const { location }: Props = Astro.props;
       </li>
       <li class="child" role="menuitem">
         <a href="/live">Livestream</a>
-    </li>
+      </li>
     </ul>
   </li>
   <li class="parent" role="menuitem">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -32,8 +32,8 @@ const speakers = [taylor, greg, andreea, alice, waffle, aeva];
     </p>
     <ButtonGroup style="cutout" align="left">
         <Button
-          link="https://event.onliveevent.nl/rustweek-2026"
-          >Tickets</>
+            link="/live"
+          >Livestream</>
         <Button link="#week-schedule" ty="secondary">Week schedule</Button>
     </ButtonGroup>
 


### PR DESCRIPTION
**Merge at the start of the conference, on monday**. 

Marks places that said "get your ticket here" as "ticket sales has closed" and replaces the buttons on the homepage to get a ticket with a "watch livestream" button, which at the start of the conference seems more relevant

depends on #55 